### PR TITLE
Adding DEMO VIDEO of local_diect_ul_api function

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ fbx-delta-nba_bash_api.sh
 _________________________________________
 
 - ### NOTE (20250323):  $${\color{red}\text{  Adding file and directory upload over websocket support: }}$$
-- ##### FRONTEND FUNCTION (upload files / directory): local_direct_ul_api
+  - ##### FRONTEND FUNCTION (upload files / directory): local_direct_ul_api
+  - ##### DEMO VIDEO IN REPOSITORY: local_direct_ul_api-video-example.webm
   
 - ### NOTE (20250323):  $${\color{purple}\text{  The library now support --debug / --trace options }}$$
 


### PR DESCRIPTION
Adding DEMO VIDEO of local_direct_ul_api function:

*--> See DEMO VIDEO : local_direct_ul_api-video-example.webm

NB:
* --> local_direct_ul_api function reach BASH 5 limits, forking process, using files descriptors, etc. If you encountered any issues, please report here: https://github.com/nbanb/fbx-delta-nba_bash_api.sh/issues/new